### PR TITLE
Partial fix for Issue #2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,9 @@
 *~
 *.pyc
 
+# background.txt gets updated in minute ways, ignore any changes.
+background.txt
+
 # ignore to rst readme
 README
 tests/setupscript.sh

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@
 
 '''Step 1: Background Knowledge'''
 
-# Sample data is built in from the 'Toy Cancer' Dataset, retrieve it with sample_data
+# Sample data is built in from the 'Toy Cancer' Dataset, retrieve it with example_data
 >>> bk = boostsrl.example_data('background')
 
 # Create the background knowledge or 'Modes,' where 'cancer' is the target we want to predict.

--- a/background.txt
+++ b/background.txt
@@ -1,8 +1,0 @@
-setParam: numOfClauses=8.
-useStdLogicVariables: true.
-setParam: treeDepth=4.
-setParam: nodeSize=2.
-mode: friends(+Person, -Person).
-mode: friends(-Person, +Person).
-mode: smokes(+Person).
-mode: cancer(+Person).

--- a/boostsrl/boostsrl.py
+++ b/boostsrl/boostsrl.py
@@ -128,8 +128,8 @@ class modes(object):
         self.resampleNegs = resampleNegs
         #self.queryPred = 'advisedby/2'
 
-        # Many of the arguments in the modes object are optional this shows us the values of the ones that are neither false nor none.
-
+        # Many of the arguments in the modes object are optional this shows us the values of the ones that are neither false nor none
+        
         types = {
             'background should be a list.': isinstance(background, list),
             'target should be a list.': isinstance(target, list),
@@ -322,3 +322,4 @@ class test(object):
                 value_regression = full[1]
                 inference_dict[key_predicate] = value_regression
         return inference_dict
+

--- a/boostsrl/boostsrl.py
+++ b/boostsrl/boostsrl.py
@@ -273,6 +273,11 @@ class train(object):
 
 class test(object):
 
+    # Possibly a partial fix to Issue #3: checking for the .aucTemp.txt.lock
+    if os.path.isfile('boostsrl/test/AUC/.aucTemp.txt.lock'):
+        print('Found lock file boostsrl/test/AUC/.aucTemp.txt.lock, removing it:')
+        os.remove('boostsrl/test/AUC/.aucTemp.txt.lock')
+
     def __init__(self, model, test_pos, test_neg, test_facts, trees=10):
         write_to_file(test_pos, 'boostsrl/test/test_pos.txt')
         write_to_file(test_neg, 'boostsrl/test/test_neg.txt')


### PR DESCRIPTION
I still have not been able to fully recreate the bug, but I solved one part of it: the creation of a lock file .aucTemp.txt.lock if testing crashes.

Previously if this occurred, the lock file would need to be manually deleted, otherwise it simply appeared that inference took forever.